### PR TITLE
Add GeoJSON file outputs for site polygons. 

### DIFF
--- a/src/ReefGuideAPI.jl
+++ b/src/ReefGuideAPI.jl
@@ -244,7 +244,8 @@ export
 export
     assess_reef_site,
     identify_potential_sites_edges,
-    filter_intersecting_sites
+    filter_sites,
+    output_geojson
 
 # Geometry handling
 export

--- a/src/geom_handlers/common_assessment.jl
+++ b/src/geom_handlers/common_assessment.jl
@@ -1,6 +1,7 @@
 """ Functions common to both site_assessment methods."""
 
-using LinearAlgebra, Dates
+using Dates
+using LinearAlgebra
 
 include("geom_ops.jl")
 
@@ -250,7 +251,7 @@ end
     )::Nothing
 
 Writes out GeoJSON file to a target directory. Output file will be located at location:
-"`output_dir`/output_dir_`region`_`current_date_time`.geojson"
+"`output_dir`/output_sites_`region`.geojson"
 
 # Arguments
 - `df` : DataFrame intended for writing to geojson file.
@@ -265,7 +266,7 @@ function output_geojson(
     GDF.write(
         joinpath(
             output_dir,
-            "output_sites_$(region)_$(Dates.format(now(), "Y-mm-dd_THH-MM")).geojson"
+            "output_sites_$(region).geojson"
         ),
         df;
         crs=GI.crs(first(df.geometry))

--- a/src/geom_handlers/common_assessment.jl
+++ b/src/geom_handlers/common_assessment.jl
@@ -1,6 +1,6 @@
 """ Functions common to both site_assessment methods. """
 
-using LinearAlgebra
+using LinearAlgebra, Dates
 
 include("geom_ops.jl")
 
@@ -236,7 +236,12 @@ function filter_sites(res_df::DataFrame)::DataFrame
 end
 
 """
-    output_geojson(df::DataFrame, region::String, output_dir::String)::Nothing
+    output_geojson(
+        df::DataFrame,
+        region::String,
+        output_dir::String,
+        target_crs::GeoFormatTypes.CoordinateReferenceSystemFormat
+    )::Nothing
 
 Writes out GeoJSON file to a target directory. Output file will be located at location:
 "`output_dir`/output_dir_`region`_`current_date_time`.geojson"
@@ -245,15 +250,21 @@ Writes out GeoJSON file to a target directory. Output file will be located at lo
 - `df` : DataFrame intended for writing to geojson file.
 - `region` : Region name for labelling output file.
 - `output_dir` : Directory to write geojson file to.
+- `target_crs` : Coordinate Reference System of output polygons (matches input raster file).
 """
-function output_geojson(df::DataFrame, region::String, output_dir::String)::Nothing
+function output_geojson(
+    df::DataFrame,
+    region::String,
+    output_dir::String,
+    target_crs::GeoFormatTypes.CoordinateReferenceSystemFormat
+)::Nothing
     GDF.write(
         joinpath(
             output_dir,
             "output_sites_$(region)_$(Dates.format(now(), "Y-mm-dd_THH-MM")).geojson"
         ),
         df;
-        crs=crs(df.geometry[1])
+        crs=target_crs
     )
 
     return nothing

--- a/src/geom_handlers/common_assessment.jl
+++ b/src/geom_handlers/common_assessment.jl
@@ -73,12 +73,18 @@ function line_angle(a::T, b::T)::Float64 where {T<:Vector{Tuple{Float64,Float64}
 end
 
 """
-    filter_far_polygons(gdf::DataFrame, pixel::GIWrap.Point, lat::Float64)::BitVector
+    filter_far_polygons(gdf::DataFrame, pixel::GIWrap.Point, lat::Float64, dist::Union{Int64,Float64})::BitVector
 
 Filter out reefs that are > 10km from the target pixel (currently hardcoded threshold).
 """
-function filter_far_polygons(gdf::DataFrame, pixel::GeometryBasics.Point, lat::Float64, dist::Int64)::BitVector
-    return (GO.distance.(GO.centroid.(gdf[:, first(GI.geometrycolumns(gdf))]), [pixel]) .< meters_to_degrees(dist, lat))
+function filter_far_polygons(
+    gdf::DataFrame,
+    pixel::GeometryBasics.Point,
+    lat::Float64,
+    dist::Union{Int64,Float64}
+)::BitVector
+    geoms = gdf[:, first(GI.geometrycolumns(gdf))]
+    return (GO.distance.(GO.centroid.(geoms), [pixel]) .< meters_to_degrees(dist, lat))
 end
 
 """
@@ -205,7 +211,8 @@ Filter out sites where the qc_flag indicates a suitabiltiy < `surr_threshold` in
 Identify and keep the highest scoring site polygon where site polygons are overlapping.
 
 # Arguments
-- `res_df` : Results DataFrame containing potential site polygons (output from `identify_potential_sites()` or `identify_potential_sites_edges()`).
+- `res_df` : Results DataFrame containing potential site polygons
+             (output from `identify_potential_sites()` or `identify_potential_sites_edges()`).
 
 # Returns
 DataFrame containing only the highest scoring sites where site polygons intersect, and

--- a/src/geom_handlers/common_assessment.jl
+++ b/src/geom_handlers/common_assessment.jl
@@ -196,16 +196,17 @@ function initial_search_rotation(
 end
 
 """
-    filter_intersecting_sites(res_df::DataFrame)::DataFrame
+    filter_sites_and_output(res_df::DataFrame, region::String, output_dir::String)::Nothing
 
 Filter out sites where the qc_flag indicates a suitabiltiy < `surr_threshold` in searching.
 Identify and keep the highest scoring site polygon where site polygons are overlapping.
 
 # Arguments
-- `res_df` : Results DataFrame containing potential site polygons (output from
-`identify_potential_sites()` or `identify_potential_sites_edges()`).
+- `res_df` : Results DataFrame containing potential site polygons (output from `identify_potential_sites()` or `identify_potential_sites_edges()`).
+- `region` : Region name to attach to output files.
+- `output_dir` : Folder path to write `.geojson` files to.
 """
-function filter_intersecting_sites(res_df::DataFrame, region::String, output_dir::String)::Nothing
+function filter_sites_and_output(res_df::DataFrame, region::String, output_dir::String)::Nothing
     res_df.row_ID = 1:size(res_df, 1)
     ignore_list = []
 

--- a/src/geom_handlers/common_assessment.jl
+++ b/src/geom_handlers/common_assessment.jl
@@ -241,17 +241,3 @@ function filter_intersecting_sites(res_df::DataFrame, region::String, output_dir
 
     return nothing
 end
-
-target_crs = EPSG(7844)
-
-"""
-"""
-function get_crs_unit(target_crs::GeoFormatTypes.CoordinateReferenceSystemFormat)::String
-    crs_string = GeoFormatTypes.val(convert(WellKnownText, target_crs))
-    crs_type = split(crs_string, ",")[1] |> occursin()
-    if occursin("degree", unit_str[1])
-        return "degree"
-    elseif occursin("m", unit_str[1])
-        return "m"
-    end
-end

--- a/src/geom_handlers/common_assessment.jl
+++ b/src/geom_handlers/common_assessment.jl
@@ -239,8 +239,7 @@ end
     output_geojson(
         df::DataFrame,
         region::String,
-        output_dir::String,
-        target_crs::GeoFormatTypes.CoordinateReferenceSystemFormat
+        output_dir::String
     )::Nothing
 
 Writes out GeoJSON file to a target directory. Output file will be located at location:
@@ -250,13 +249,11 @@ Writes out GeoJSON file to a target directory. Output file will be located at lo
 - `df` : DataFrame intended for writing to geojson file.
 - `region` : Region name for labelling output file.
 - `output_dir` : Directory to write geojson file to.
-- `target_crs` : Coordinate Reference System of output polygons (matches input raster file).
 """
 function output_geojson(
     df::DataFrame,
     region::String,
-    output_dir::String,
-    target_crs::GeoFormatTypes.CoordinateReferenceSystemFormat
+    output_dir::String
 )::Nothing
     GDF.write(
         joinpath(
@@ -264,7 +261,7 @@ function output_geojson(
             "output_sites_$(region)_$(Dates.format(now(), "Y-mm-dd_THH-MM")).geojson"
         ),
         df;
-        crs=target_crs
+        crs=GI.crs(first(df.geometry))
     )
 
     return nothing

--- a/src/geom_handlers/common_assessment.jl
+++ b/src/geom_handlers/common_assessment.jl
@@ -156,7 +156,8 @@ end
         pixel::GeometryBasics.Point{2, Float64},
         geom_buff::GI.Wrappers.Polygon,
         gdf::DataFrame,
-        reef_outlines::Vector{Vector{GeometryBasics.Line{2, Float64}}}
+        reef_outlines::Vector{Vector{GeometryBasics.Line{2, Float64}}};
+        search_buffer::Union{Int64,Float64}=20000.0
     )::Float64
 
 Identifies the closest edge to the target `pixel`/'`geom_buff` and returns the initial rotation
@@ -172,9 +173,10 @@ function initial_search_rotation(
     pixel::GeometryBasics.Point{2,Float64},
     geom_buff::GI.Wrappers.Polygon,
     gdf::DataFrame,
-    reef_outlines::Vector{Vector{GeometryBasics.Line{2,Float64}}}
+    reef_outlines::Vector{Vector{GeometryBasics.Line{2,Float64}}};
+    search_buffer::Union{Int64,Float64}=20000.0
 )::Float64
-    distance_indices = filter_far_polygons(gdf, pixel, pixel[2], 20000)
+    distance_indices = filter_far_polygons(gdf, pixel, pixel[2], search_buffer)
     reef_lines = reef_outlines[distance_indices]
     reef_lines = reef_lines[
         GO.within.([pixel], gdf[distance_indices, first(GI.geometrycolumns(gdf))])

--- a/src/geom_handlers/geom_ops.jl
+++ b/src/geom_handlers/geom_ops.jl
@@ -87,7 +87,11 @@ function get_points(geom)
     end
 end
 
-function rotate_geom(geom, degrees::Float64)
+function rotate_geom(
+    geom,
+    degrees::Float64,
+    target_crs::GeoFormatTypes.CoordinateReferenceSystemFormat
+)
     degrees == 0.0 && return geom
 
     theta = deg2rad(degrees)
@@ -113,7 +117,7 @@ function rotate_geom(geom, degrees::Float64)
         new_points[i] = rotate_point(new_points[i])
     end
 
-    return create_poly(new_points, GI.crs(geom))
+    return create_poly(new_points, target_crs)
 end
 
 """

--- a/src/geom_handlers/parq_site_assessment.jl
+++ b/src/geom_handlers/parq_site_assessment.jl
@@ -15,10 +15,24 @@ include("common_assessment.jl")
         surr_threshold::Float64=0.33
     )::Tuple{Float64,Int64,GI.Wrappers.Polygon,Int64}
 
-Assesses the rotations of a search box `geom` for their pixel score. Returns the highest score,
-rotation step, polygon and a quality control flag for each assessment. Rotation steps are returned
-so that the `start_rot` angle is 0, rotations anti-clockwise are negative and rotations clockwise are
+Assesses the rotations of a search box `geom` for their suitability score (calculated as the
+proportion of pixels that meet all specified criteria thresholds). Search box rotation steps
+are returned so that the `start_rot` angle is 0, rotations anti-clockwise are negative and
+rotations clockwise are
 positive.
+
+# Arguments
+- `rel_pix` : DataFrame containing the point data for pixels that are within maxmimum user search box dimensions from a pixel.
+- `geom` : Starting search box for assessment.
+- `max_count` : The maximum number of pixels that can intersect the search box (used to standardise scores between 0 and 1).
+- `target_crs` : Coordinate Reference System used for analysis vector and raster data.
+- `degree_step` : Step to vary the search box rotations.
+- `start_rot` : Starting angle rotation that aligns the box with the closest reef edge.
+- `n_per_side` : Number of rotations to perform around the starting search box angle.
+- `surr_threshold` : Suitability threshold, below which sites are excluded from result sets.
+
+# Returns
+Returns the highest score, rotation step, polygon and a quality control flag for each assessment.
 """
 function assess_reef_site(
     rel_pix::DataFrame,
@@ -53,8 +67,8 @@ end
 """
     identify_potential_sites_edges(
         df::DataFrame,
-        indices_pixels::Raster,
-        indices::Vector{CartesianIndex{2}},
+        search_pixels::DataFrame,
+        res::Float64,
         gdf::DataFrame,
         x_dist::Union{Int64,Float64},
         y_dist::Union{Int64,Float64},
@@ -66,16 +80,16 @@ end
         surr_threshold::Float64=0.33
     )::DataFrame
 
-Identify the most suitable site polygons for each pixel in the `search_pixels` raster where
-`indices` denotes which pixels to check for suitability. `x_dist` and `y_dist` are x and y
-lengths of the search polygon in meters. A buffer of `rst_stack` resolution is applied to the search box.
-And angle from a pixel to a reef edge is identified and used for searching with custom rotation
-parameters. Method is currently opperating for CRS in degrees units.
+Identify the most suitable site polygons for each pixel in the `search_pixels` DataFrame.
+`x_dist` and `y_dist` are x and y lengths of the search polygon in meters. A buffer of the
+raster files' resolution is applied to the search box. And angle from a pixel to a reef edge
+is identified and used for searching with custom rotation parameters.
+Method is currently opperating for CRS in degrees units.
 
 # Arguments
 - `df` : DataFrame containing environmental variables for assessment.
-- `indices_pixels` : Raster that matches indices for lon/lat information.
-- `indices` : Vector of CartesianIndices noting pixels to assess sites.
+- `search_pixels` : DataFrame containing lon and lat columns for each pixel that is intended for analysis.
+- `res` : Resolution of the original raster pixels. Can by found via `abs(step(dims(raster, X)))`.
 - `gdf` : GeoDataFrame containing the reef outlines used to align the search box edge.
 - `x_dist` : Length of horizontal side of search box (in meters).
 - `y_dist` : Length of vertical side of search box (in meters).
@@ -91,8 +105,8 @@ DataFrame containing highest score, rotation and polygon for each assessment at 
 """
 function identify_potential_sites_edges(
     df::DataFrame,
-    indices_pixels::Raster,
-    indices::Vector{CartesianIndex{2}},
+    search_pixels::DataFrame,
+    res::Float64,
     gdf::DataFrame,
     x_dist::Union{Int64,Float64},
     y_dist::Union{Int64,Float64},
@@ -105,7 +119,6 @@ function identify_potential_sites_edges(
 )::DataFrame
     reef_lines = reef_lines[gdf.management_area .== region]
     gdf = gdf[gdf.management_area .== region, :]
-    res = abs(step(dims(indices_pixels, X)))
     max_count = (
         (x_dist / degrees_to_meters(res, mean(indices_pixels.dims[2]))) *
         ((y_dist + 2 * degrees_to_meters(res, mean(indices_pixels.dims[2]))) /
@@ -113,13 +126,13 @@ function identify_potential_sites_edges(
     )
 
     # Search each location to assess
-    best_score = zeros(length(indices))
-    best_poly = Vector(undef, length(indices))
-    best_rotation = zeros(Int64, length(indices))
-    quality_flag = zeros(Int64, length(indices))
-    for (i, index) in enumerate(indices)
-        lon = dims(indices_pixels, X)[index[1]]
-        lat = dims(indices_pixels, Y)[index[2]]
+    best_score = zeros(length(search_pixels.lon))
+    best_poly = Vector(undef, length(search_pixels.lon))
+    best_rotation = zeros(Int64, length(search_pixels.lon))
+    quality_flag = zeros(Int64, length(search_pixels.lon))
+    for (i, index) in enumerate(eachrow(search_pixels))
+        lon = index.lon
+        lat = index.lat
         geom_buff = initial_search_box((lon, lat), x_dist, y_dist, target_crs, res)
 
         pixel = GO.Point(lon, lat)

--- a/src/geom_handlers/parq_site_assessment.jl
+++ b/src/geom_handlers/parq_site_assessment.jl
@@ -7,7 +7,8 @@ include("common_assessment.jl")
     assess_reef_site(
         rel_pix::DataFrame,
         geom::GI.Wrappers.Polygon,
-        max_count::Float64;
+        max_count::Float64,
+        target_crs::GeoFormatTypes.CoordinateReferenceSystemFormat;
         degree_step::Float64=15.0,
         start_rot::Float64=0.0,
         n_per_side::Int64=2,
@@ -22,7 +23,8 @@ positive.
 function assess_reef_site(
     rel_pix::DataFrame,
     geom::GI.Wrappers.Polygon,
-    max_count::Float64;
+    max_count::Float64,
+    target_crs::GeoFormatTypes.CoordinateReferenceSystemFormat;
     degree_step::Float64=15.0,
     start_rot::Float64=0.0,
     n_per_side::Int64=2,
@@ -35,7 +37,7 @@ function assess_reef_site(
     qc_flag = zeros(Int64, n_rotations)
 
     for (j, r) in enumerate(rotations)
-        rot_geom = rotate_geom(geom, r)
+        rot_geom = rotate_geom(geom, r, target_crs)
         score[j] = size(rel_pix[GO.intersects.([rot_geom], rel_pix.geometry), :], 1) / max_count
         best_poly[j] = rot_geom
 
@@ -136,7 +138,8 @@ function identify_potential_sites_edges(
         b_score, b_rot, b_poly, qc_flag = assess_reef_site(
             rel_pix,
             geom_buff,
-            max_count;
+            max_count,
+            target_crs;
             degree_step=degree_step,
             start_rot=rot_angle,
             n_per_side=n_rot_p_side,


### PR DESCRIPTION
function `filter_sites_and_output()` filters out intersecting polygons and polygons that have scores < 0.33 suitability (default - threshold can be user defined).
Requires the desired output directory and region name for labelling as inputs. 