### PR TITLE
Fix auth middleware

### DIFF
--- a/sample.config.toml
+++ b/sample.config.toml
@@ -2,7 +2,8 @@
 PREPPED_DATA_DIR = "/data"
 
 [server_config]
-CACHE_DIR = "./cache"
+TIFF_CACHE_DIR = "<some location to cache geotiffs>"
+REGIONAL_CACHE_DIR = "<some location to cache regional datasets>"
 DEBUG_MODE = "false"
 COG_THREADS = "2"  # Optional, Number of threads to use when creating COGs (defaults to 1)
 TILE_SIZE = "256"  # Optional, tile block size to use (defaults to 256)

--- a/src/Middleware.jl
+++ b/src/Middleware.jl
@@ -40,7 +40,7 @@ function setup_jwt_middleware(config::Dict)
     public_key = jwks_json["keys"][1]["n"]
     rsa_public = JSONWebTokens.RS256(public_key)
 
-    function jwt_auth_middleware(handler)
+    return function jwt_auth_middleware(handler)
         return function(req::HTTP.Request)
             auth_header = HTTP.header(req, "Authorization", "")
             if !startswith(auth_header, "Bearer ")

--- a/src/ReefGuideAPI.jl
+++ b/src/ReefGuideAPI.jl
@@ -183,7 +183,7 @@ function tile_size(config::Dict)::Tuple
     return tile_dims
 end
 
-function get_auth_router(config :: Dict)
+function get_auth_router(config::Dict)
     # Setup auth middleware - depends on config.toml - can return identity func
     auth = setup_jwt_middleware(config)
     return router(""; middleware=[auth])

--- a/src/ReefGuideAPI.jl
+++ b/src/ReefGuideAPI.jl
@@ -183,10 +183,10 @@ function tile_size(config::Dict)::Tuple
     return tile_dims
 end
 
-function get_auth_middleware(config :: Dict)
+function get_auth_router(config :: Dict)
     # Setup auth middleware - depends on config.toml - can return identity func
     auth = setup_jwt_middleware(config)
-    return [auth]
+    return router(""; middleware=[auth])
 end
 
 """
@@ -209,7 +209,7 @@ function start_server(config_path)
 
     # setting up middleware
     @info "Setting up middleware."
-    auth = get_middleware(config)
+    auth = get_auth_router(config)
     @info "Done."
 
     @info "Setting up region routes..."
@@ -218,14 +218,6 @@ function start_server(config_path)
 
     @info "Setting up tile routes..."
     setup_tile_routes(auth)
-
-    @info "Setting up region routes..."
-    setup_region_routes(config)
-    @info "Completed region routes setup."
-
-    @info "Setting up tile routes..."
-    setup_tile_routes()
-    @info "Completed tile routes setup."
 
     @info "Initialisation complete, starting server on port 8000."
     @info "Starting with $(Threads.nthreads()) threads..."

--- a/src/ReefGuideAPI.jl
+++ b/src/ReefGuideAPI.jl
@@ -205,27 +205,25 @@ function start_server(config_path)
 
     @info "Parsing configuration from $(config_path)..."
     config = TOML.parsefile(config_path)
-    @info "Successfully parsed configuration."
 
-    # setting up middleware
-    @info "Setting up middleware."
+    @info "Setting up auth middleware and router."
     auth = get_auth_router(config)
-    @info "Done."
 
     @info "Setting up region routes..."
     setup_region_routes(config, auth)
-    @info "Completed region routes setup."
 
     @info "Setting up tile routes..."
     setup_tile_routes(auth)
 
-    @info "Initialisation complete, starting server on port 8000."
-    @info "Starting with $(Threads.nthreads()) threads..."
-    if Threads.nthreads() > 1
-        serveparallel(middleware=[CorsMiddleware], host="0.0.0.0", port=8000)
-    else
-        serve(middleware=[CorsMiddleware], host="0.0.0.0", port=8000)
-    end
+    port = 8000
+    @info "Initialisation complete, starting server on port $(port) with $(Threads.nthreads()) threads."
+
+    serve(
+        middleware=[CorsMiddleware],
+        host="0.0.0.0",
+        port=port,
+        parallel=Threads.nthreads() > 1
+    )
 end
 
 export

--- a/src/assessment/criteria.jl
+++ b/src/assessment/criteria.jl
@@ -99,7 +99,7 @@ end
 function setup_region_routes(config, auth)
     reg_assess_data = setup_regional_data(config)
 
-    @get("/assess/{reg}/{rtype}", middleware=[auth])
+    @get auth("/assess/{reg}/{rtype}")
     function (req::Request, reg::String, rtype::String)
         qp = queryparams(req)
         file_id = string(hash(qp))
@@ -155,14 +155,14 @@ function setup_region_routes(config, auth)
         return file(mask_path)
     end
 
-    @get("/bounds/{reg}", middleware=[auth])
+    @get auth("/bounds/{reg}")
     function (req::Request, reg::String)
         rst_stack = reg_assess_data[reg].stack
 
         return json(Rasters.bounds(rst_stack))
     end
 
-    @get("/tile/{z}/{x}/{y}",middleware=[auth])
+    @get auth("/tile/{z}/{x}/{y}")
     function (req::Request, z::Int64, x::Int64, y::Int64)
         # http://127.0.0.1:8000/tile/10/10/10?region=Cairns-Cooktown&rtype=slopes&criteria_names=Depth,Slope,Rugosity&lb=-9.0,0.0,0.0&ub=-2.0,40.0,0.0
         qp = queryparams(req)
@@ -262,7 +262,7 @@ function setup_region_routes(config, auth)
     end
 
     # Parse the form data and return it
-    @post("/form", middleware=[auth])
+    @post auth("/form")
     function(req)
         data = formdata(req)
         return data

--- a/src/assessment/criteria.jl
+++ b/src/assessment/criteria.jl
@@ -99,8 +99,7 @@ end
 function setup_region_routes(config, auth)
     reg_assess_data = setup_regional_data(config)
 
-    @get auth("/assess/{reg}/{rtype}")
-    function (req::Request, reg::String, rtype::String)
+    @get auth("/assess/{reg}/{rtype}") function (req::Request, reg::String, rtype::String)
         qp = queryparams(req)
         file_id = string(hash(qp))
         mask_temp_path = _cache_location(config)
@@ -155,15 +154,13 @@ function setup_region_routes(config, auth)
         return file(mask_path)
     end
 
-    @get auth("/bounds/{reg}")
-    function (req::Request, reg::String)
+    @get auth("/bounds/{reg}") function (req::Request, reg::String)
         rst_stack = reg_assess_data[reg].stack
 
         return json(Rasters.bounds(rst_stack))
     end
 
-    @get auth("/tile/{z}/{x}/{y}")
-    function (req::Request, z::Int64, x::Int64, y::Int64)
+    @get auth("/tile/{z}/{x}/{y}") function (req::Request, z::Int64, x::Int64, y::Int64)
         # http://127.0.0.1:8000/tile/10/10/10?region=Cairns-Cooktown&rtype=slopes&criteria_names=Depth,Slope,Rugosity&lb=-9.0,0.0,0.0&ub=-2.0,40.0,0.0
         qp = queryparams(req)
         file_id = string(hash(qp))
@@ -262,8 +259,7 @@ function setup_region_routes(config, auth)
     end
 
     # Parse the form data and return it
-    @post auth("/form")
-    function(req)
+    @post auth("/form") function(req)
         data = formdata(req)
         return data
     end

--- a/src/assessment/tiles.jl
+++ b/src/assessment/tiles.jl
@@ -157,14 +157,12 @@ function masked_nearest(
 end
 
 function setup_tile_routes(auth)
-    @get auth("/to-tile/{zoom}/{lon}/{lat}")
-    function (req::Request, zoom::Int64, lon::Float64, lat::Float64)
+    @get auth("/to-tile/{zoom}/{lon}/{lat}") function (req::Request, zoom::Int64, lon::Float64, lat::Float64)
         x, y = _lon_lat_to_tile(zoom, lon, lat)
         return json(Dict(:x=>x, :y=>y))
     end
 
-    @get auth("/to-lonlat/{zoom}/{x}/{y}")
-    function (req::Request, zoom::Int64, x::Int64, y::Int64)
+    @get auth("/to-lonlat/{zoom}/{x}/{y}") function (req::Request, zoom::Int64, x::Int64, y::Int64)
         lon_min, lon_max, lat_max, lat_min = _tile_bounds(zoom, x, y)
         return json(
                 Dict(

--- a/src/assessment/tiles.jl
+++ b/src/assessment/tiles.jl
@@ -157,13 +157,13 @@ function masked_nearest(
 end
 
 function setup_tile_routes(auth)
-    @get("/to-tile/{zoom}/{lon}/{lat}", middleware=[auth])
+    @get auth("/to-tile/{zoom}/{lon}/{lat}")
     function (req::Request, zoom::Int64, lon::Float64, lat::Float64)
         x, y = _lon_lat_to_tile(zoom, lon, lat)
         return json(Dict(:x=>x, :y=>y))
     end
 
-    @get("/to-lonlat/{zoom}/{x}/{y}", middleware=[auth])
+    @get auth("/to-lonlat/{zoom}/{x}/{y}")
     function (req::Request, zoom::Int64, x::Int64, y::Int64)
         lon_min, lon_max, lat_max, lat_min = _tile_bounds(zoom, x, y)
         return json(


### PR DESCRIPTION
Fix auth setup.

Use an `auth` router to specify what routes are authenticated.

Oxygen seems to be ok with creating another router on the root (base path).

https://oxygenframework.github.io/Oxygen.jl/stable/#Middleware

