### PR TITLE
Fix query parser

### DIFF
--- a/src/criteria_assessment/query_parser.jl
+++ b/src/criteria_assessment/query_parser.jl
@@ -13,15 +13,18 @@ Queries should take the form of:
 Tuple of criteria names, lower bounds, upper bounds
 """
 function parse_criteria_query(qp::Dict)::Tuple
-    criteria_names = keys(criteria_data_map())
-    lbs = []
-    ubs = []
-    for k in criteria_names
+    criteria = string.(keys(criteria_data_map()))
+    criteria_names = String[]
+    lbs = String[]
+    ubs = String[]
+
+    for k in criteria
         if k ∉ keys(qp)
             continue
         end
 
         lb, ub = string.(split(qp[k], ":"))
+        push!(criteria_names, k)
         push!(lbs, lb)
         push!(ubs, ub)
     end


### PR DESCRIPTION
As in title. Address query bounds not actually being parsed correctly.

Test url:

http://127.0.0.1:8000/tile/10/10/10?region=Cairns-Cooktown&rtype=slopes&criteria_names=Depth,Slope,Rugosity&lb=-9.0,0.0,0.0&ub=-2.0,40.0,0.0