### PR TITLE
Fix tile cache filename

### DIFF
--- a/src/Middleware.jl
+++ b/src/Middleware.jl
@@ -13,7 +13,6 @@ const CORS_HEADERS = [
 # https://juliaweb.github.io/HTTP.jl/stable/examples/#Cors-Server
 function CorsMiddleware(handler)
     return function (req::HTTP.Request)
-        @debug "CORS middleware"
         # determine if this is a pre-flight request from the browser
         if HTTP.method(req) == "OPTIONS"
             return HTTP.Response(200, CORS_HEADERS)

--- a/src/criteria_assessment/tiles.jl
+++ b/src/criteria_assessment/tiles.jl
@@ -170,7 +170,7 @@ function setup_tile_routes(config, auth)
         # http://127.0.0.1:8000/tile/8/231/139?region=Cairns-Cooktown&rtype=slopes&Depth=-9.0:0.0&Slope=0.0:40.0&Rugosity=0.0:3.0
 
         qp = queryparams(req)
-        mask_path = cache_filename(qp, config, "", "png")
+        mask_path = cache_filename(qp, config, "tile-zxy_$(z)_$(x)_$(y)", "png")
         if isfile(mask_path)
             return file(mask_path; headers=TILE_HEADERS)
         end

--- a/src/site_assessment/common_functions.jl
+++ b/src/site_assessment/common_functions.jl
@@ -259,9 +259,13 @@ Writes out GeoJSON file to a target directory. Output file will be located at lo
 - `destination_path` : File path to write geojson file to.
 - `df` : DataFrame intended for writing to geojson file.
 """
-function output_geojson(destination_path::String, df::DataFrame; output_crs=EPSG(4326))::Nothing
+function output_geojson(
+    destination_path::String, df::DataFrame; output_crs=EPSG(4326)
+)::Nothing
     out_df = copy(df)
-    out_df.geometry = GO.reproject(out_df.geometry, GI.crs(first(out_df.geometry)), output_crs)
+    out_df.geometry = GO.reproject(
+        out_df.geometry, GI.crs(first(out_df.geometry)), output_crs
+    )
 
     GDF.write(destination_path, out_df; crs=GI.crs(first(out_df.geometry)))
 


### PR DESCRIPTION
XYZ missing from the cache filename.
Files look like:  _.cache\tiff\3143377215267477499tile-zxy_12_3704_2237.png_

This causes terrible race conditions and wrong tiles. What I don't understand is how this wasn't an issue before