### PR TITLE
Add buffer distance into max_count and max_offset.

### DIFF
--- a/src/site_assessment/best_fit_polygons.jl
+++ b/src/site_assessment/best_fit_polygons.jl
@@ -160,7 +160,7 @@ function identify_edge_aligned_sites(
             (2 * res)
         )
 
-        local bounds = [
+        bounds .= Float64[
             lon - max_offset,
             lon + max_offset,
             lat - max_offset,

--- a/src/site_assessment/best_fit_polygons.jl
+++ b/src/site_assessment/best_fit_polygons.jl
@@ -137,7 +137,7 @@ function identify_edge_aligned_sites(
     region_long = REGIONAL_DATA["region_long_names"][region]
     reef_lines = reef_lines[gdf.management_area .== region_long]
     gdf = gdf[gdf.management_area .== region_long, :]
-    max_count = (x_dist * y_dist) / (pixel_unit^2)
+    max_count = (x_dist * y_dist) / (degrees_to_meters(res, mean(search_pixels.lat))^2)
 
     # Search each location to assess
     best_score = zeros(length(search_pixels.lon))

--- a/src/site_assessment/best_fit_polygons.jl
+++ b/src/site_assessment/best_fit_polygons.jl
@@ -20,6 +20,13 @@ are returned so that the `start_rot` angle is 0, rotations anti-clockwise are ne
 rotations clockwise are
 positive.
 
+# Extended help
+The scores produced are a proportion of the polygon that are covered by valid pixel points,
+relative to the maximum number of points (`max_count`) (0-1). `max_count` is approximate
+(determined by user `x_dist` and `y_dist` box dimensions) and doesn't account for buffering
+and rotation of the search box. In rare cases scores could be > 1, however returned values
+are capped at max 1.
+
 # Arguments
 - `rel_pix` : The point data for relevant pixels that are within the search area around a pixel.
 - `geom` : Starting search box for assessment.
@@ -35,13 +42,6 @@ positive.
 - Highest scoring rotation step
 - Highest scoring polygon
 - Quality control flag for site, indicating if `surr_threshold` was met in the highest scoring rotation.
-
-# Extended help
-The scores produced are a proportion of the polygon that are covered by valid pixel points,
-relative to the maximum number of points (`max_count`) (0-1). `max_count` is approximate
-(determined by user `x_dist` and `y_dist` box dimensions) and doesn't account for buffering
-and rotation of the search box. In rare cases scores could be > 1, however returned values
-are capped at max 1.
 """
 function assess_reef_site(
     rel_pix::DataFrame,

--- a/src/site_assessment/best_fit_polygons.jl
+++ b/src/site_assessment/best_fit_polygons.jl
@@ -307,8 +307,8 @@ function identify_edge_aligned_sites(
     degree_step::Float64=15.0,
     n_rot_per_side::Int64=2
 )::DataFrame
-    reef_lines = reef_lines[gdf.management_area .== region]
-    gdf = gdf[gdf.management_area .== region, :]
+    reef_lines = reef_lines[gdf.management_area_short .== region]
+    gdf = gdf[gdf.management_area_short .== region, :]
     res = abs(step(dims(rst_stack, X)))
 
     # Search each location to assess

--- a/src/site_assessment/best_fit_polygons.jl
+++ b/src/site_assessment/best_fit_polygons.jl
@@ -157,10 +157,10 @@ function identify_edge_aligned_sites(
 
         max_offset = (
             abs(meters_to_degrees(maximum([x_dist, y_dist]) / 2, lat)) +
-            (2 * degrees_to_meters(res, lat))
+            (2 * res)
         )
 
-        bounds = [
+        local bounds = [
             lon - max_offset,
             lon + max_offset,
             lat - max_offset,


### PR DESCRIPTION
Previously the buffering distance wasn't applied to max_count. Additionally have moved to max_offset to allow for full rotation of the search box without going outside of the rel_pix bounds. And adjusted options if there are no rel_pix for a search box (returns standard geometry to output valid DataFrame, but will be filtered out at later steps).
