### PR TITLE
Add detail of what the identified rot_angle means for use in rotate_geom

### DIFF
--- a/src/site_assessment/best_fit_polygons.jl
+++ b/src/site_assessment/best_fit_polygons.jl
@@ -21,7 +21,7 @@ rotations clockwise are
 positive.
 
 # Arguments
-- `rel_pix` : DataFrame containing the point data for pixels that are within maxmimum user search box dimensions from a pixel. `rel` is short for relevant, as these pixels have been filtered to surround the target area only.
+- `rel_pix` : The point data for relevant pixels that are within the search area around a pixel.
 - `geom` : Starting search box for assessment.
 - `max_count` : The maximum number of pixels that can intersect the search box (used to standardise scores between 0 and 1).
 - `target_crs` : Coordinate Reference System used for analysis vector and raster data.

--- a/src/site_assessment/best_fit_polygons.jl
+++ b/src/site_assessment/best_fit_polygons.jl
@@ -21,7 +21,7 @@ rotations clockwise are
 positive.
 
 # Arguments
-- `rel_pix` : DataFrame containing the point data for pixels that are within maxmimum user search box dimensions from a pixel.
+- `rel_pix` : DataFrame containing the point data for pixels that are within maxmimum user search box dimensions from a pixel. `rel` is short for relevant, as these pixels have been filtered to surround the target area only.
 - `geom` : Starting search box for assessment.
 - `max_count` : The maximum number of pixels that can intersect the search box (used to standardise scores between 0 and 1).
 - `target_crs` : Coordinate Reference System used for analysis vector and raster data.

--- a/src/site_assessment/common_functions.jl
+++ b/src/site_assessment/common_functions.jl
@@ -160,10 +160,7 @@ end
     )::Float64
 
 Identifies the closest edge to the target `pixel`/'`geom_buff`. The angle required to rotate
-geom_buff to match this reef edge is calculated. This angle is the angle relative to the
-default `geom_buff` horizontal orientation. Therefore, if returned angle = 45 degrees,
-`rot_geom(geom_buff, 45)` will rotate `geom_buff` by 45 degrees to match the identified reef
-edge.
+geom_buff by to match this reef edge is calculated.
 
 # Arguments
 - `pixel` : Target point at the center of the search polygon.
@@ -174,6 +171,11 @@ edge.
 
 # Returns
 Rotation angle required to match reef edge when used in `rotate_geom(geom_buff, rot_angle)`.
+
+# Extended help
+The returned angle is the angle relative to the default `geom_buff` horizontal orientation.
+Therefore, if returned angle = 45 degrees, `rot_geom(geom_buff, 45)` will rotate `geom_buff`
+by 45 degrees to match the identified reef edge.
 """
 function initial_search_rotation(
     pixel::GeometryBasics.Point{2,Float64},

--- a/src/site_assessment/common_functions.jl
+++ b/src/site_assessment/common_functions.jl
@@ -168,6 +168,12 @@ angle required to match the edge line.
 - `gdf` : GeoDataFrame containing a geometry column used for pixel masking.
 - `reef_outlines` : Line segments for the outlines of each reef in `gdf`.
 - `search_buffer` : Distance to search from pixel to find closest reef.
+
+# Returns
+Angle of rotation required to match reef edge line. This angle is the angle relative to the
+default `geom_buff` horizontal orientation. Therefore, if returned angle = 45 degrees,
+`rot_geom(geom_buff, 45)` will rotate `geom_buff` by 45 degrees to match the identified reef
+edge.
 """
 function initial_search_rotation(
     pixel::GeometryBasics.Point{2,Float64},

--- a/src/site_assessment/common_functions.jl
+++ b/src/site_assessment/common_functions.jl
@@ -159,8 +159,7 @@ end
         search_buffer::Union{Int64,Float64}=20000.0
     )::Float64
 
-Identifies the closest edge to the target `pixel`/'`geom_buff` and returns the initial rotation
-angle required to match the edge line.
+Identifies the closest edge to the target `pixel`/'`geom_buff`.
 
 # Arguments
 - `pixel` : Target point at the center of the search polygon.

--- a/src/site_assessment/common_functions.jl
+++ b/src/site_assessment/common_functions.jl
@@ -162,6 +162,11 @@ end
 Identifies the closest edge to the target `pixel`/'`geom_buff`. The angle required to rotate
 geom_buff by to match this reef edge is calculated.
 
+# Extended help
+The returned angle is the angle relative to the default `geom_buff` horizontal orientation.
+Therefore, if returned angle = 45 degrees, `rot_geom(geom_buff, 45)` will rotate `geom_buff`
+by 45 degrees to match the identified reef edge.
+
 # Arguments
 - `pixel` : Target point at the center of the search polygon.
 - `geom_buff` : Initial search box with zero rotation.
@@ -171,11 +176,6 @@ geom_buff by to match this reef edge is calculated.
 
 # Returns
 Rotation angle required to match reef edge when used in `rotate_geom(geom_buff, rot_angle)`.
-
-# Extended help
-The returned angle is the angle relative to the default `geom_buff` horizontal orientation.
-Therefore, if returned angle = 45 degrees, `rot_geom(geom_buff, 45)` will rotate `geom_buff`
-by 45 degrees to match the identified reef edge.
 """
 function initial_search_rotation(
     pixel::GeometryBasics.Point{2,Float64},

--- a/src/site_assessment/common_functions.jl
+++ b/src/site_assessment/common_functions.jl
@@ -159,7 +159,11 @@ end
         search_buffer::Union{Int64,Float64}=20000.0
     )::Float64
 
-Identifies the closest edge to the target `pixel`/'`geom_buff`.
+Identifies the closest edge to the target `pixel`/'`geom_buff`. The angle required to rotate
+geom_buff to match this reef edge is calculated. This angle is the angle relative to the
+default `geom_buff` horizontal orientation. Therefore, if returned angle = 45 degrees,
+`rot_geom(geom_buff, 45)` will rotate `geom_buff` by 45 degrees to match the identified reef
+edge.
 
 # Arguments
 - `pixel` : Target point at the center of the search polygon.
@@ -169,10 +173,7 @@ Identifies the closest edge to the target `pixel`/'`geom_buff`.
 - `search_buffer` : Distance to search from pixel to find closest reef.
 
 # Returns
-Angle of rotation required to match reef edge line. This angle is the angle relative to the
-default `geom_buff` horizontal orientation. Therefore, if returned angle = 45 degrees,
-`rot_geom(geom_buff, 45)` will rotate `geom_buff` by 45 degrees to match the identified reef
-edge.
+Rotation angle required to match reef edge when used in `rotate_geom(geom_buff, rot_angle)`.
 """
 function initial_search_rotation(
     pixel::GeometryBasics.Point{2,Float64},


### PR DESCRIPTION
Add detail to `identify_search_rotation()` to specify what the returned angle represents for using in `rotate_geom()`, where `rotate_geom()` requires angle to rotate `by`.
Addresses issue #37