### PR TITLE
Early exit on empty query (potential fix for #44)

### DIFF
--- a/src/criteria_assessment/query_thresholds.jl
+++ b/src/criteria_assessment/query_thresholds.jl
@@ -273,7 +273,12 @@ function threshold_mask(
         (lons[1] .<= lookup.lons .<= lons[2]) .&
         (lat1 .<= lookup.lats .<= lat2)
     )
+
     lookup = lookup[within_search, :]
+    if nrow(lookup) == 0
+        # Exit as there is no data
+        return Raster(zeros(0,0), dims=([0], [0]))
+    end
 
     # Need to pass in full representation of the raster as the lookup table relies on
     # the original Cartesian indices.

--- a/src/criteria_assessment/query_thresholds.jl
+++ b/src/criteria_assessment/query_thresholds.jl
@@ -277,7 +277,7 @@ function threshold_mask(
     lookup = lookup[within_search, :]
     if nrow(lookup) == 0
         # Exit as there is no data
-        return Raster(zeros(0,0), dims=([0], [0]))
+        return Raster(zeros(0, 0); dims=([0], [0]))
     end
 
     # Need to pass in full representation of the raster as the lookup table relies on


### PR DESCRIPTION
As in title.

Added an early exit to avoid assessing an empty domain - which I still cannot recreate but I think this resolves the primary problem.