### PR TITLE
Adding other display information

### DIFF
--- a/src/utility/regions_criteria_setup.jl
+++ b/src/utility/regions_criteria_setup.jl
@@ -72,15 +72,27 @@ struct CriteriaMetadata
     display_label::String
     description::String
     units::String
+    payload_prefix::String
+    default_bounds::OptionalValue{Bounds}
 
     function CriteriaMetadata(;
         id::String,
         file_suffix::String,
         display_label::String,
         description::String,
-        units::String
+        units::String,
+        payload_prefix::String,
+        default_bounds::OptionalValue{Bounds}=nothing
     )
-        return new(id, file_suffix, display_label, description, units)
+        return new(
+            id,
+            file_suffix,
+            display_label,
+            description,
+            units,
+            payload_prefix,
+            default_bounds
+        )
     end
 end
 
@@ -91,42 +103,51 @@ const ASSESSMENT_CRITERIA::Dict{String,CriteriaMetadata} = Dict(
         file_suffix="_bathy",
         display_label="Depth",
         description="TODO",
-        units="TODO"
+        units="TODO",
+        payload_prefix="depth_",
+        default_bounds=Bounds(; min=-10, max=-2)
     ),
     "Slope" => CriteriaMetadata(;
         id="Slope",
         file_suffix="_slope",
         display_label="Slope",
         description="TODO",
-        units="TODO"
+        units="TODO",
+        payload_prefix="slope_"
     ),
     "Turbidity" => CriteriaMetadata(;
         id="Turbidity",
         file_suffix="_turbid",
         display_label="Turbidity",
         description="TODO",
-        units="TODO"
+        units="TODO",
+        payload_prefix="turbidity_"
     ),
     "WavesHs" => CriteriaMetadata(;
         id="WavesHs",
         file_suffix="_waves_Hs",
         display_label="Wave Height (m)",
         description="TODO",
-        units="TODO"
+        units="TODO",
+        payload_prefix="waves_height_",
+        default_bounds=Bounds(; min=0, max=1)
     ),
     "WavesTp" => CriteriaMetadata(;
         id="WavesTp",
         file_suffix="_waves_Tp",
         display_label="Wave Period (s)",
         description="TODO",
-        units="TODO"
+        units="TODO",
+        payload_prefix="waves_period_",
+        default_bounds=Bounds(; min=0, max=6)
     ),
     "Rugosity" => CriteriaMetadata(;
         id="Rugosity",
         file_suffix="_rugosity",
         display_label="Rugosity",
         description="TODO",
-        units="TODO"
+        units="TODO",
+        payload_prefix="rugosity_"
     )
 )
 

--- a/src/utility/regions_criteria_setup.jl
+++ b/src/utility/regions_criteria_setup.jl
@@ -74,6 +74,8 @@ struct CriteriaMetadata
     units::String
     payload_prefix::String
     default_bounds::OptionalValue{Bounds}
+    min_tooltip::String
+    max_tooltip::String
 
     function CriteriaMetadata(;
         id::String,
@@ -82,7 +84,9 @@ struct CriteriaMetadata
         description::String,
         units::String,
         payload_prefix::String,
-        default_bounds::OptionalValue{Bounds}=nothing
+        default_bounds::OptionalValue{Bounds}=nothing,
+        min_tooltip::String,
+        max_tooltip::String
     )
         return new(
             id,
@@ -91,7 +95,9 @@ struct CriteriaMetadata
             description,
             units,
             payload_prefix,
-            default_bounds
+            default_bounds,
+            min_tooltip,
+            max_tooltip
         )
     end
 end
@@ -105,7 +111,9 @@ const ASSESSMENT_CRITERIA::Dict{String,CriteriaMetadata} = Dict(
         description="TODO",
         units="TODO",
         payload_prefix="depth_",
-        default_bounds=Bounds(; min=-10, max=-2)
+        default_bounds=Bounds(; min=-10, max=-2),
+        min_tooltip="TODO",
+        max_tooltip="TODO"
     ),
     "Slope" => CriteriaMetadata(;
         id="Slope",
@@ -113,7 +121,9 @@ const ASSESSMENT_CRITERIA::Dict{String,CriteriaMetadata} = Dict(
         display_label="Slope",
         description="TODO",
         units="TODO",
-        payload_prefix="slope_"
+        payload_prefix="slope_",
+        min_tooltip="TODO",
+        max_tooltip="TODO"
     ),
     "Turbidity" => CriteriaMetadata(;
         id="Turbidity",
@@ -121,7 +131,9 @@ const ASSESSMENT_CRITERIA::Dict{String,CriteriaMetadata} = Dict(
         display_label="Turbidity",
         description="TODO",
         units="TODO",
-        payload_prefix="turbidity_"
+        payload_prefix="turbidity_",
+        min_tooltip="TODO",
+        max_tooltip="TODO"
     ),
     "WavesHs" => CriteriaMetadata(;
         id="WavesHs",
@@ -130,7 +142,9 @@ const ASSESSMENT_CRITERIA::Dict{String,CriteriaMetadata} = Dict(
         description="TODO",
         units="TODO",
         payload_prefix="waves_height_",
-        default_bounds=Bounds(; min=0, max=1)
+        default_bounds=Bounds(; min=0, max=1),
+        min_tooltip="TODO",
+        max_tooltip="TODO"
     ),
     "WavesTp" => CriteriaMetadata(;
         id="WavesTp",
@@ -139,7 +153,9 @@ const ASSESSMENT_CRITERIA::Dict{String,CriteriaMetadata} = Dict(
         description="TODO",
         units="TODO",
         payload_prefix="waves_period_",
-        default_bounds=Bounds(; min=0, max=6)
+        default_bounds=Bounds(; min=0, max=6),
+        min_tooltip="TODO",
+        max_tooltip="TODO"
     ),
     "Rugosity" => CriteriaMetadata(;
         id="Rugosity",
@@ -147,7 +163,9 @@ const ASSESSMENT_CRITERIA::Dict{String,CriteriaMetadata} = Dict(
         display_label="Rugosity",
         description="TODO",
         units="TODO",
-        payload_prefix="rugosity_"
+        payload_prefix="rugosity_",
+        min_tooltip="TODO",
+        max_tooltip="TODO"
     )
 )
 

--- a/src/utility/regions_criteria_setup.jl
+++ b/src/utility/regions_criteria_setup.jl
@@ -63,14 +63,18 @@ Metadata for assessment criteria including file naming conventions.
 - `id::String` : Unique system identifier for the criteria
 - `file_suffix::String` : File suffix pattern for data files
 - `display_label::String` : Human-readable label for UI display
-- `description::String` : Human-readable info about this criteria
+- `subtitle::String` : Human-readable info about this criteria on subtitle of slider
 - `units::String` : Human-readable info about relevant units
+- `payload_prefix::String` : The prefix for building the job payload
+- `default_bounds::OptionalValue{Bounds}` : The default bounds for the parameter sliders
+- `min_tooltip::String` : Tooltip text on min slider
+- `max_tooltip::String` : Tooltip text on max slider
 """
 struct CriteriaMetadata
     id::String
     file_suffix::String
     display_label::String
-    description::String
+    subtitle::String
     units::String
     payload_prefix::String
     default_bounds::OptionalValue{Bounds}
@@ -81,7 +85,7 @@ struct CriteriaMetadata
         id::String,
         file_suffix::String,
         display_label::String,
-        description::String,
+        subtitle::String,
         units::String,
         payload_prefix::String,
         default_bounds::OptionalValue{Bounds}=nothing,
@@ -92,7 +96,7 @@ struct CriteriaMetadata
             id,
             file_suffix,
             display_label,
-            description,
+            subtitle,
             units,
             payload_prefix,
             default_bounds,
@@ -108,7 +112,7 @@ const ASSESSMENT_CRITERIA::Dict{String,CriteriaMetadata} = Dict(
         id="Depth",
         file_suffix="_bathy",
         display_label="Depth",
-        description="TODO",
+        subtitle="TODO",
         units="TODO",
         payload_prefix="depth_",
         default_bounds=Bounds(; min=-10, max=-2),
@@ -119,7 +123,7 @@ const ASSESSMENT_CRITERIA::Dict{String,CriteriaMetadata} = Dict(
         id="Slope",
         file_suffix="_slope",
         display_label="Slope",
-        description="TODO",
+        subtitle="TODO",
         units="TODO",
         payload_prefix="slope_",
         min_tooltip="TODO",
@@ -129,7 +133,7 @@ const ASSESSMENT_CRITERIA::Dict{String,CriteriaMetadata} = Dict(
         id="Turbidity",
         file_suffix="_turbid",
         display_label="Turbidity",
-        description="TODO",
+        subtitle="TODO",
         units="TODO",
         payload_prefix="turbidity_",
         min_tooltip="TODO",
@@ -139,7 +143,7 @@ const ASSESSMENT_CRITERIA::Dict{String,CriteriaMetadata} = Dict(
         id="WavesHs",
         file_suffix="_waves_Hs",
         display_label="Wave Height (m)",
-        description="TODO",
+        subtitle="TODO",
         units="TODO",
         payload_prefix="waves_height_",
         default_bounds=Bounds(; min=0, max=1),
@@ -150,7 +154,7 @@ const ASSESSMENT_CRITERIA::Dict{String,CriteriaMetadata} = Dict(
         id="WavesTp",
         file_suffix="_waves_Tp",
         display_label="Wave Period (s)",
-        description="TODO",
+        subtitle="TODO",
         units="TODO",
         payload_prefix="waves_period_",
         default_bounds=Bounds(; min=0, max=6),
@@ -161,7 +165,7 @@ const ASSESSMENT_CRITERIA::Dict{String,CriteriaMetadata} = Dict(
         id="Rugosity",
         file_suffix="_rugosity",
         display_label="Rugosity",
-        description="TODO",
+        subtitle="TODO",
         units="TODO",
         payload_prefix="rugosity_",
         min_tooltip="TODO",

--- a/src/utility/routes.jl
+++ b/src/utility/routes.jl
@@ -57,6 +57,8 @@ function setup_utility_routes(config, auth)
                 :display_title => criteria.metadata.display_label,
                 :display_subtitle => criteria.metadata.description,
                 :units => criteria.metadata.units,
+                :min_tooltip => criteria.metadata.min_tooltip,
+                :max_tooltip => criteria.metadata.max_tooltip,
 
                 # default min/max
                 :default_min_val => default_bounds.min,

--- a/src/utility/routes.jl
+++ b/src/utility/routes.jl
@@ -40,9 +40,30 @@ function setup_utility_routes(config, auth)
 
         # Format each criteria with min/max bounds
         for (id::String, criteria::BoundedCriteria) in regional_criteria_lookup
+            # build default min/max
+            default_bounds::Bounds = something(
+                criteria.metadata.default_bounds, criteria.bounds
+            )
+
             output_dict[id] = OrderedDict(
+                # Unique ID (and data field name)
+                :id => id,
+
+                # min/max bounds
                 :min_val => criteria.bounds.min,
-                :max_val => criteria.bounds.max
+                :max_val => criteria.bounds.max,
+
+                # display info
+                :display_title => criteria.metadata.display_label,
+                :display_subtitle => criteria.metadata.description,
+                :units => criteria.metadata.units,
+
+                # default min/max
+                :default_min_val => default_bounds.min,
+                :default_max_val => default_bounds.max,
+
+                # how to build a job payload (prefix of job i.e. depth_) then build depth_min depth_max
+                :payload_property_prefix => criteria.metadata.payload_prefix
             )
         end
 

--- a/src/utility/routes.jl
+++ b/src/utility/routes.jl
@@ -55,7 +55,7 @@ function setup_utility_routes(config, auth)
 
                 # display info
                 :display_title => criteria.metadata.display_label,
-                :display_subtitle => criteria.metadata.description,
+                :display_subtitle => criteria.metadata.subtitle,
                 :units => criteria.metadata.units,
                 :min_tooltip => criteria.metadata.min_tooltip,
                 :max_tooltip => criteria.metadata.max_tooltip,


### PR DESCRIPTION
Current response indicated below - will fill out TODOs

Adds id, display title/subtitle, units, default min/max, and payload prop prefix (for building jobs) into the dictionary.
```
{
  "Turbidity": {
    "id": "Turbidity",
    "min_val": 1,
    "max_val": 969,
    "display_title": "Turbidity",
    "display_subtitle": "TODO",
    "units": "TODO",
    "default_min_val": 1,
    "default_max_val": 969,
    "payload_property_prefix": "turbidity_"
  },
  "WavesTp": {
    "id": "WavesTp",
    "min_val": 1.4799601,
    "max_val": 10.763558,
    "display_title": "Wave Period (s)",
    "display_subtitle": "TODO",
    "units": "TODO",
    "default_min_val": 0,
    "default_max_val": 6,
    "payload_property_prefix": "waves_period_"
  },
  "WavesHs": {
    "id": "WavesHs",
    "min_val": 0.16966935,
    "max_val": 3.3906436,
    "display_title": "Wave Height (m)",
    "display_subtitle": "TODO",
    "units": "TODO",
    "default_min_val": 0,
    "default_max_val": 1,
    "payload_property_prefix": "waves_height_"
  },
  "Slope": {
    "id": "Slope",
    "min_val": 0.012705713,
    "max_val": 47.122066,
    "display_title": "Slope",
    "display_subtitle": "TODO",
    "units": "TODO",
    "default_min_val": 0.012705713,
    "default_max_val": 47.122066,
    "payload_property_prefix": "slope_"
  },
  "Depth": {
    "id": "Depth",
    "min_val": -17.897633,
    "max_val": -0.025795916,
    "display_title": "Depth",
    "display_subtitle": "TODO",
    "units": "TODO",
    "default_min_val": -10,
    "default_max_val": -2,
    "payload_property_prefix": "depth_"
  }
}
```